### PR TITLE
Increment MongoQueryBuilder total query count

### DIFF
--- a/src/main/java/it/mathsanalysis/load/document/query/MongoQueryBuilder.java
+++ b/src/main/java/it/mathsanalysis/load/document/query/MongoQueryBuilder.java
@@ -302,6 +302,9 @@ public final class MongoQueryBuilder<T> implements DocumentQueryBuilder<T> {
             return newVal;
         });
 
+        // keep track of the total number of built queries
+        queryStats.merge("total_queries", 1L, (o, n) -> o instanceof Long ? (Long) o + (Long) n : n);
+
         queryStats.put("last_query_type", queryType);
         queryStats.put("last_query_time", System.currentTimeMillis());
     }

--- a/src/test/java/it/mathsanalysis/load/document/query/MongoQueryBuilderTest.java
+++ b/src/test/java/it/mathsanalysis/load/document/query/MongoQueryBuilderTest.java
@@ -1,0 +1,24 @@
+package it.mathsanalysis.load.document.query;
+
+import org.junit.jupiter.api.Test;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+public class MongoQueryBuilderTest {
+
+    @Test
+    void totalQueriesShouldIncrement() {
+        MongoQueryBuilder<Object> builder = new MongoQueryBuilder<>();
+        Map<String, Object> stats = builder.getQueryStats();
+        assertEquals(0L, stats.get("total_queries"));
+
+        builder.buildFindByIdQuery("1");
+        long afterFirst = (Long) builder.getQueryStats().get("total_queries");
+        assertEquals(1L, afterFirst);
+
+        builder.buildInsertQuery(new Object(), null);
+        long afterSecond = (Long) builder.getQueryStats().get("total_queries");
+        assertEquals(2L, afterSecond);
+    }
+}


### PR DESCRIPTION
## Summary
- increment `total_queries` counter when building queries
- add a regression test for query statistics

## Testing
- `gradle test` *(fails: SSL handshake exception while resolving dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_68897f39c180832abfd861835a294569