### PR TITLE
Fix README reactive streams example

### DIFF
--- a/README.md
+++ b/README.md
@@ -195,7 +195,7 @@ userLoader.saveAsync(user, Map.of())
 
 ```java
 // Process large datasets with reactive streams
-var userPublisher = Flow.publisher(generateLargeUserDataset());
+Flow.Publisher<User> userPublisher = generateLargeUserDataset();
 
 userLoader.saveBatchAsync(userPublisher, Map.of("batchSize", 500))
     .thenAccept(batchResult -> {


### PR DESCRIPTION
## Summary
- fix invalid Flow publisher example in `README.md`

## Testing
- `gradle test` *(fails: cannot find JDK 23)*

------
https://chatgpt.com/codex/tasks/task_e_68897f390920832a80f2de66481e2aa4